### PR TITLE
Game edit bugfix

### DIFF
--- a/src/components/forms/GameForm.jsx
+++ b/src/components/forms/GameForm.jsx
@@ -15,6 +15,7 @@ export const GameForm = () => {
     const [currentGenreChoice, setCurrentGenreChoice] = useState(0)
     const [genreChoices, setGenreChoices] = useState([])
     const [importedGenreChoices, setImportedGenreChoices] = useState([])
+    const [importedGameGenres, setImportedGameGenres] = useState([])
     const [playerCount, setPlayerCount] = useState(0)
     const [headerURL, setHeaderURL] = useState("")
 
@@ -66,6 +67,9 @@ export const GameForm = () => {
             const importedGameGenres = gameToImport.gameGenres.map(gameGenre => gameGenre.genreId)
             setGenreChoices(importedGameGenres)
             setImportedGenreChoices(importedGameGenres)
+        })
+        getAllGameGenresByGameId(gameId).then(gameGenresArray => {
+            setImportedGameGenres(gameGenresArray)
         })
     }
 
@@ -122,6 +126,22 @@ export const GameForm = () => {
         }
     }
 
+    const modifyGameGenres = () => {
+        const arrayOfPromises = []
+
+        for (const genre of genres) {
+            if (doesGenreChoiceExist(genreChoices, genre) && !doesGenreChoiceExist(importedGenreChoices, genre)) {
+                arrayOfPromises.push(createNewGameGenre(genre.id))
+            } else if (!doesGenreChoiceExist(genreChoices, genre) && doesGenreChoiceExist(importedGenreChoices, genre)) {
+                arrayOfPromises.push(deleteExistingGameGenre(genre.id))
+            }
+        }
+
+        const results = Promise.all(arrayOfPromises)
+
+        return results
+    }
+
 
     const handleSubmit = () => {
         if (!title || !playerCount || !gameTypeChoice || genreChoices.length === 0 || !headerURL) {
@@ -141,10 +161,9 @@ export const GameForm = () => {
         
         if (gameId) {
             updateGame(copy).then(() => {
-                handleModifyingGameGenres()
-                setTimeout(() => {
-                    navigate("/games")
-                }, 250);
+                modifyGameGenres()
+            }).then(() => {
+                navigate("/games")
             })
         } else {
             createGame(copy).then(() => {
@@ -174,10 +193,8 @@ export const GameForm = () => {
 
 
     const deleteExistingGameGenre = (genreId) => {
-        getAllGameGenresByGameId(gameId).then(gameGenresArray => {
-            const gameGenreToDelete = gameGenresArray.find(gameGenre => gameGenre.genreId === genreId)
-            deleteGameGenre(gameGenreToDelete.id)
-        })
+        const gameGenreToDelete = importedGameGenres.find(gameGenre => gameGenre.genreId === genreId)
+        return deleteGameGenre(gameGenreToDelete.id)
     }
     
 

--- a/src/components/forms/GameForm.jsx
+++ b/src/components/forms/GameForm.jsx
@@ -115,16 +115,6 @@ export const GameForm = () => {
         return genreChoiceArray.find(genreChoice => genreChoice === genreToCheckAgainst.id)
     }
 
-    
-    const handleModifyingGameGenres = () => {
-        for (const genre of genres) {
-            if (doesGenreChoiceExist(genreChoices, genre) && !doesGenreChoiceExist(importedGenreChoices, genre)) {
-                createNewGameGenre(genre.id)
-            } else if (!doesGenreChoiceExist(genreChoices, genre) && doesGenreChoiceExist(importedGenreChoices, genre)) {
-                deleteExistingGameGenre(genre.id)
-            }
-        }
-    }
 
     const modifyGameGenres = () => {
         const arrayOfPromises = []

--- a/src/components/forms/GameForm.jsx
+++ b/src/components/forms/GameForm.jsx
@@ -142,6 +142,9 @@ export const GameForm = () => {
         if (gameId) {
             updateGame(copy).then(() => {
                 handleModifyingGameGenres()
+                setTimeout(() => {
+                    navigate("/games")
+                }, 250);
             })
         } else {
             createGame(copy).then(() => {
@@ -150,7 +153,6 @@ export const GameForm = () => {
                 navigate("/games")
             })
         }
-        
     }
 
     


### PR DESCRIPTION
### Purpose
To prevent navigation from the Edit Game view until all fetch calls for submitting an edited game have been resolved

### Files Changed
- Updated logic to use new promises to prevent navigation until all fetches are resolved when deleting gameGenres while editing a game in `GameForm.jsx`

### To Test
Fetch, host related `frontend-capstone-api` json server, and run "npm run dev"
- Log in as an employee user
- Navigate to the Edit Game view of a game, delete a genre, and submit
- Confirm game does not appear in the list of filtered games when filtering for the deleted genre without reloading the page