### PR TITLE
Games View Toggle Buttons

### DIFF
--- a/src/components/games/FilterBar.jsx
+++ b/src/components/games/FilterBar.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react"
 import { getAllGameTypes } from "../../services/gameTypeService.js"
 import { getAllGenres } from "../../services/genreService.js"
-import { Box, Button, FormControl, Grid, InputLabel, MenuItem, Select, TextField } from "@mui/material"
+import { Box, Button, FormControl, Grid, InputLabel, MenuItem, Select, TextField, ToggleButton, ToggleButtonGroup } from "@mui/material"
 
 export const FilterBar = ({ games, setFilteredGames, user }) => {
     const [gameTypes, setGameTypes] = useState([])
@@ -70,6 +70,13 @@ export const FilterBar = ({ games, setFilteredGames, user }) => {
     }
 
 
+    const handleGamesListToggle = (event, newToggle) => {
+        if (newToggle !== null) {
+            setShowOnlyOwnedGames(newToggle)
+        }
+    }
+
+
 
     return (
         <Grid container direction={"row"} justifyContent={"space-between"} marginBottom={3} paddingTop={3}>
@@ -117,22 +124,18 @@ export const FilterBar = ({ games, setFilteredGames, user }) => {
                     <Button variant="outlined" onClick={clearFilters}>Clear Filters</Button>
                 </Grid>
             </Box>
-            <Box display={"flex"} alignItems={"center"}>
-                <Grid>
-                    <Button
-                        variant="outlined"
-                        onClick={() => {setShowOnlyOwnedGames(false)}}
-                    >
-                        All
-                    </Button>
-                    <Button
-                        variant="outlined"
-                        onClick={() => {setShowOnlyOwnedGames(true)}}
-                    >
-                        My
-                    </Button>
-                </Grid>
-            </Box>
+            <ToggleButtonGroup
+                value={showOnlyOwnedGames}
+                exclusive
+                onChange={handleGamesListToggle}
+            >
+                <ToggleButton value={false}>
+                    All Games
+                </ToggleButton>
+                <ToggleButton value={true}>
+                    My Games
+                </ToggleButton>
+            </ToggleButtonGroup>
         </Grid>
     )
 }


### PR DESCRIPTION
### Purpose
To change the standard MUI Buttons used to switch between showing all games and only the games the user owns in the Games view to MUI Toggle Buttons. This is to hopefully provide better context to the user of the current state of the page they are viewing

### Files Changed
- Updated rendering and logic to use Toggle Buttons instead of standard Buttons in `FilterBar.jsx`

### To Test
Fetch, host related `frontend-capstone-api` json server, and run "npm run dev"
- Confirm buttons on right side of filter bar are Toggle Buttons in Games view
- Confirm Toggle Buttons work as expected